### PR TITLE
Added override for stacking conflict

### DIFF
--- a/50_pop-shell.gschema.override
+++ b/50_pop-shell.gschema.override
@@ -2,6 +2,9 @@
 # default: ['<Super>v', '<Super>m']
 # conflict: toggle maximized
 toggle-message-tray = ['<Super>v']
+# default: ['<Super>s']
+# conflict: toggle stacking
+toggle-overview = []
 
 [org.gnome.desktop.wm.keybindings]
 # default: ['<Alt>F4']

--- a/gnome-shell-extension-pop-shell.spec
+++ b/gnome-shell-extension-pop-shell.spec
@@ -8,7 +8,7 @@
 
 Name:           gnome-shell-extension-%{extension}
 Version:        0.1.0
-Release:        0.6%{?dist}
+Release:        0.7%{?dist}
 Summary:        GNOME Shell extension for advanced tiling window management
 # The entire source code is GPLv3 except math.js which is ASL 2.0
 License:        GPLv3 and ASL 2.0

--- a/gnome-shell-extension-pop-shell.spec
+++ b/gnome-shell-extension-pop-shell.spec
@@ -67,6 +67,9 @@ install -D -p -m 0644 %{S:1} %{buildroot}%{_datadir}/glib-2.0/schemas/50_%{exten
 
 
 %changelog
+* Fri Oct 02 2020 Drew DeVore <drew@devorcula.com> - 0.1.0-0.7.20200929gitb9f8d96
+- Added override for stacking conflict
+
 * Thu Oct 01 2020 Carl George <carl@george.computer> - 0.1.0-0.6.20200929gitb9f8d96
 - Latest upstream commit
 


### PR DESCRIPTION
This PR creates an override that blanks the super+s overview keyboard shortcut. That shortcut was stepping on the stacking shortcut.